### PR TITLE
refactor(core): replace deprecated vue flow options parameter

### DIFF
--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -179,7 +179,7 @@
 
     const dragging = ref(false);
     const lastPosition = ref<XYPosition | null>()
-    const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow({id: props.id});
+    const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow(props.id);
     const edgeReplacer = ref({});
     const hiddenNodes = ref<string[]>([]);
     const collapsed = ref(new Set<string>());

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -17,7 +17,7 @@ const base = {
             const vueflowId = ref(Math.random().toString());
             const {
                 fitView
-            } = useVueFlow({id: vueflowId.value});
+            } = useVueFlow(vueflowId.value);
 
             nextTick(() => {
                 fitView();


### PR DESCRIPTION
Remove usage of the deprecated options object parameter with the id one, as per the latest API guidelines. This change ensures compatibility with future versions and removes the related console warning.

Related to https://github.com/kestra-io/kestra/issues/7804.