### PR TITLE
fix: yaml.parse has a more open return type

### DIFF
--- a/src/utils/YamlUtils.ts
+++ b/src/utils/YamlUtils.ts
@@ -40,11 +40,11 @@ export const YamlUtils = {
     });
   },
 
-  parse(item: string, throwIfError = true) {
+  parse<T = any>(item: string, throwIfError = true): T | undefined {
     if (item === undefined) return undefined;
 
     try {
-      return JsYaml.load(item);
+      return JsYaml.load(item) as any;
     } catch (e) {
       if (throwIfError) throw e;
       return undefined;


### PR DESCRIPTION
This change will avoid this kind of issue by allowing us to specify what type we expect to come out of the parse
 
<img width="631" alt="Screenshot 2025-04-16 at 10 43 10" src="https://github.com/user-attachments/assets/d1279f27-427b-49fd-bc84-27e6cd2ebd96" />
