### PR TITLE
feat: support parentId in getLastTaskid

### DIFF
--- a/src/utils/YamlUtils.test.ts
+++ b/src/utils/YamlUtils.test.ts
@@ -1796,7 +1796,26 @@ describe("getLastTask", () => {
             type: io.kestra.plugin.core.flow.Parallel
         `;
         const result = YamlUtils.getLastTask(yaml);
-        expect(result).toEqual("task2");
+        expect(result).toBe("task2");
+    });
+
+    test("returns last subtask in flowable", () => {
+        const yaml = `
+        id: test
+        namespace: test
+        tasks:
+          - id: task1
+            type: io.kestra.plugin.core.log.Log
+          - id: task2
+            type: io.kestra.plugin.core.flow.Parallel
+            tasks:
+              - id: task3
+                type: foo
+              - id: task4
+                type: baz
+        `;
+        const result = YamlUtils.getLastTask(yaml, "task2");
+        expect(result).toBe("task4");
     });
 
     test("returns undefined when no tasks exist", () => {

--- a/src/utils/YamlUtils.test.ts
+++ b/src/utils/YamlUtils.test.ts
@@ -1858,23 +1858,3 @@ describe("getMapAtPosition", () => {
                             });
     })
 })
-
-describe("idExists", () => {
-    test("returns true if id exists", () => {
-        const yaml = `
-        tasks:
-          - id: task1
-            type: io.kestra.plugin.core.log.Log
-        `;
-        expect(YamlUtils.idExists(yaml, "task1")).toBe(true);
-    });
-
-    test("returns false if id does not exist", () => {
-        const yaml = `
-        tasks:
-          - id: task1
-            type: io.kestra.plugin.core.log.Log
-        `;
-        expect(YamlUtils.idExists(yaml, "task2")).toBe(false);
-    });
-})

--- a/src/utils/YamlUtils.ts
+++ b/src/utils/YamlUtils.ts
@@ -965,9 +965,21 @@ export const YamlUtils = {
     return tasks && tasks.value.items && tasks.value.items.length >= 1;
   },
 
-  getNextTaskId(target: string, flowSource: string, flowGraph: any) {
+  /**
+   * Gets aliased task id from the flow graph
+   * @param target the task whose id we want to get 
+   * @param flowSource the source of the flow
+   * @param flowGraph the flow graph to follow to the source
+   * @returns the targetId if the task is found, then, following 
+   * the graph, the first taskId who can be extracted (that has a type)
+  */
+  getNextTaskId(target: string, flowSource: string, flowGraph: { 
+        edges: {
+            source: string, 
+            target: string 
+        }[] }) {
     while (this.extractTask(flowSource, target) === undefined) {
-      const edge = flowGraph.edges.find((e: any) => e.source === target);
+      const edge = flowGraph.edges.find((e) => e.source === target);
       if (!edge) {
         return null;
       }

--- a/src/utils/YamlUtils.ts
+++ b/src/utils/YamlUtils.ts
@@ -1013,18 +1013,4 @@ export const YamlUtils = {
       ? clusterTask
       : undefined;
   },
-
-  idExists(source: string, id: string) {
-    const yamlDoc = yaml.parseDocument(source) as any;
-    let idExists = false;
-    yaml.visit(yamlDoc, {
-      Map(_, map) {
-        if (map.get("id") === id) {
-          idExists = true;
-          return yaml.visit.BREAK;
-        }
-      },
-    });
-    return idExists;
-  }
 };

--- a/src/utils/YamlUtils.ts
+++ b/src/utils/YamlUtils.ts
@@ -583,7 +583,6 @@ export const YamlUtils = {
       parentTaskId,
     ) : yamlDoc;
     if(!parentTask && parentTaskId) {
-        console.log(source)
         throw new Error(`Parent task with ID ${parentTaskId} not found`);
     }
 
@@ -727,10 +726,27 @@ export const YamlUtils = {
     return parse?.tasks?.[0]?.id;
   },
 
-  getLastTask(source: string): string | undefined {
-    const parse: any = this.parse(source);
+  getLastTask(source: string, parentTaskId?: string): string | undefined {
+    if (parentTaskId) {
+      const parsed = yaml.parseDocument(source);
+      const parentTask = this._extractTask(parsed, parentTaskId) as any;
+    
+      if(!parentTask?.contents?.items) {
+        throw new Error(`Parent task with ID ${parentTaskId} not found`);
+      }
 
-    return parse?.tasks && parse.tasks?.[parse?.tasks?.length - 1]?.id;
+      const tasksNode = parentTask.contents.items.find((pair:any) => pair.key.value === "tasks");
+
+      if(!tasksNode || tasksNode?.value.value === null) {
+        return undefined;
+      }
+    
+      return tasksNode.value.items[tasksNode.value.items.length - 1].get("id");
+    }
+
+    const parsed = yaml.parse(source);
+
+    return parsed?.tasks && parsed.tasks?.[parsed?.tasks?.length - 1]?.id;
   },
 
   checkTaskAlreadyExist(source: string, taskYaml: string) {


### PR DESCRIPTION
- unskip tests for `getNextTaskId`
- add parenttaskid param to `getLastTask`
- remove duplicate function `idExists` I added it by mistake