### PR TITLE
feat: add deletSection function on yaml

### DIFF
--- a/src/utils/YamlUtils.test.ts
+++ b/src/utils/YamlUtils.test.ts
@@ -1971,3 +1971,40 @@ pluginDefaults:
         expect(result).toBe(yaml);
     })
 })
+
+describe("deleteSection", () => {
+    test("removes specified section", () => {
+        const yaml = `
+        finally:
+          - id: task1
+            type: io.kestra.plugin.core.log.Log
+          - id: task2
+            type: io.kestra.plugin.core.flow.Parallel
+        `;
+        const result = YamlUtils.deleteSection(yaml, "finally", "task1");
+        expect(result).not.toContain("- id: task1");
+    });
+
+    test("returns unchanged yaml when section doesn't exist", () => {
+        const yaml = `
+tasks:
+  - id: task1
+    type: io.kestra.plugin.core.log.Log
+        `;
+        const result = YamlUtils.deleteSection(yaml, "triggers", "task1");
+        expect(result).toBe(yaml.trim() + "\n");
+    });
+
+    test("removes section where last item was deleted", () => {
+        const yaml = `
+        tasks:
+          - id: task1
+            type: io.kestra.plugin.core.log.Log
+        finally:
+          - id: finally1
+            type: io.kestra.plugin.core.log.Log
+        `;
+        const result = YamlUtils.deleteSection(yaml, "finally", "finally1");
+        expect(result).not.toContain("finally");
+    })
+})

--- a/src/utils/YamlUtils.ts
+++ b/src/utils/YamlUtils.ts
@@ -697,6 +697,39 @@ export const YamlUtils = {
     });
     return yamlDoc.toString(TOSTRING_OPTIONS);
   },
+  
+  /**
+   * Delete an item in any section by matching it's id
+   * @param source the full yaml source
+   * @param section the yaml identifier of the section to delete from
+   * @param id the id of the item to delete
+   * @returns yaml (source) without the item
+   */
+  deleteSection(source: string, section: string, id: string) {
+    const yamlDoc = yaml.parseDocument(source) as any;
+    yaml.visit(yamlDoc, {
+      Pair(_, pair: any) {
+        if (pair.key.value === section) {
+          yaml.visit(pair.value, {
+            Map(_, map) {
+              if (map.get("id") === id) {
+                return yaml.visit.REMOVE;
+              }
+            },
+          });
+        }
+      },
+    });
+    // delete empty sections
+    yaml.visit(yamlDoc, {
+      Pair(_, pair) {
+        if (isSeq(pair.value) && pair.value.items.length === 0) {
+          return yaml.visit.REMOVE;
+        }
+      },
+    });
+    return yamlDoc.toString(TOSTRING_OPTIONS);
+  },
 
   deleteTask(source: string, taskId: string, section: string) {
     const inSection =


### PR DESCRIPTION
We need to be able to delete error handlers, finally an after blocks from the no-code editor or topology