### PR TITLE
fix: parent task disabled inc. all children

### DIFF
--- a/src/components/nodes/BasicNode.vue
+++ b/src/components/nodes/BasicNode.vue
@@ -183,7 +183,7 @@
                 return {
                     "unused-path": this.data.unused,
                     [`border-${this.borderColor}`]: this.borderColor,
-                    "disabled": this.data.node.task?.disabled,
+                    "disabled": this.data.node.task?.disabled || this.data.parent?.taskNode?.task?.disabled,
                     [this.$attrs.class]: true
                 }
             },

--- a/src/utils/VueFlowUtils.ts
+++ b/src/utils/VueFlowUtils.ts
@@ -587,6 +587,7 @@ export default {
           draggable: nodeType === "task" ? !isReadOnlyTask : false,
           data: {
             node: node,
+            parent: clusterByNodeUid[node.uid] ? clusterByNodeUid[node.uid] : undefined,
             namespace:
               clusterByNodeUid[node.uid]?.taskNode?.task?.namespace ??
               namespace,


### PR DESCRIPTION
closes #561 

Now in the `kestra-io` repo if the parent task is disabled, then all the children tasks should also be disabled.

Example YAML:
```yaml
id: weasel_605398
namespace: company.team

tasks:
  - id: outside
    type: io.kestra.plugin.core.log.Log
    message: Outside message
  - id: nested
    type: io.kestra.plugin.core.flow.Parallel
    disabled: true
    tasks:
      - id: first
        type: io.kestra.plugin.core.log.Log
        message: first child
      - id: second
        type: io.kestra.plugin.core.log.Log
        message: second child

  - id: outside2
    type: io.kestra.plugin.core.log.Log
    message: Outside message
```

## BEFORE:

<img width="2845" alt="Screenshot 2025-06-19 at 10 27 01" src="https://github.com/user-attachments/assets/f3d7b815-a750-4afe-adf7-4eca45799886" />


## AFTER:

<img width="2848" alt="Screenshot 2025-06-19 at 11 18 42" src="https://github.com/user-attachments/assets/fa9d63c3-9819-423b-ad1c-ce59eacef03b" />

