### PR TITLE
fix(ui): collapsible properties not shown

### DIFF
--- a/src/components/plugins/CollapsibleProperties.vue
+++ b/src/components/plugins/CollapsibleProperties.vue
@@ -29,7 +29,7 @@
                                     <Alert class="text-warning" />
                                 </Tooltip>
                             </span>
-                            <span class="d-flex flex-wrap align-items-center gap-2">
+                            <span class="d-flex flex-wrap gap-2">
                                 <template v-for="type in extractTypeInfo(property).types" :key="type">
                                     <a v-if="type.startsWith('#')" class="d-flex fw-bold type-box rounded fs-7 px-2 py-1" :href="type" @click.stop>
                                         <span class="ref-type">{{ className(type) }}</span><eye-outline />

--- a/storybook/components/plugins/CollapsibleProperties.stories.jsx
+++ b/storybook/components/plugins/CollapsibleProperties.stories.jsx
@@ -14,7 +14,6 @@ export default {
 };
 
 const Template = (args) => ({
-    components: {CollapsibleProperties},
     setup() {
         return () =>
             <CollapsibleProperties {...args} />


### PR DESCRIPTION
should close https://github.com/kestra-io/plugin-langchain4j/issues/71 but not sure about Bootstrap classes

I ran `npm run storybook` locally to check but I get the following error :( : 

![image](https://github.com/user-attachments/assets/6b9d770e-1ed7-4240-9085-ebd61b240999)
