### PR TITLE
fix(yaml-utils): sort top level keys when using replaceBlock

### DIFF
--- a/src/utils/FlowYamlUtils.test.ts
+++ b/src/utils/FlowYamlUtils.test.ts
@@ -1276,6 +1276,45 @@ tasks:
           "
         `)
     })
+
+    test("insert the key at the right location", () => {
+        const yamlString = `
+        id: my-flow
+        namespace: my.namespace
+
+        tasks:
+          - id: plugin1
+            type: type1
+            name: Plugin 1
+          - id: plugin2
+            type: type2
+            name: Plugin 2
+        `;
+
+        const newValue = `
+        my nice flow
+        `;
+
+        const result = YamlUtils.replaceBlockWithPath({
+            source: yamlString,
+            path: "description",
+            newContent: newValue
+        })
+        expect(result).toMatchInlineSnapshot(`
+          "id: my-flow
+          namespace: my.namespace
+          description: my nice flow
+
+          tasks:
+            - id: plugin1
+              type: type1
+              name: Plugin 1
+            - id: plugin2
+              type: type2
+              name: Plugin 2
+          "
+        `)
+    })
 })
 
 describe("getPathFromSectionAndId", () => {  


### PR DESCRIPTION
To keep comments and spaces when using no-code, we want to preserve as much of the docuement as possible.

If instead of using `load` and `dump` when a to value key changes we use `replaceBlockWithPath()` we keep the rest of the blocks.

Great improvement on no-code.