### PR TITLE
fix: consistent tooltip display for subflow nodes

### DIFF
--- a/src/components/nodes/BasicNode.vue
+++ b/src/components/nodes/BasicNode.vue
@@ -15,7 +15,7 @@
                     class="text-truncate task-title"
                 >
                     <tooltip :title="hoverTooltip">
-                        {{ title ?? trimmedId }}
+                        {{ displayTitle }}
                     </tooltip>
                 </div>
                 <span
@@ -156,6 +156,10 @@
         }
 
         return trimmedId.value;
+    })
+
+    const displayTitle = computed(() => {
+        return props.title ?? trimmedId.value;
     })
 </script>
 


### PR DESCRIPTION
## Description
fixes https://github.com/kestra-io/kestra/issues/10449

Subflow nodes now show the same tooltip content (namespace + flowId) whether collapsed or expanded.

Moved title logic into a computed property to ensure consistency.

## Screenshot
Before
<img width="371" height="83" alt="image" src="https://github.com/user-attachments/assets/17875942-7cd2-42d9-8948-a5d2d981d410" />
After
<img width="409" height="50" alt="image" src="https://github.com/user-attachments/assets/c100cb2d-a915-4111-9620-5316f519ab4b" />