### PR TITLE
Use taskRun.id to match taskRun and not taskId ensuring correct execution link for all nodes

### DIFF
--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -148,6 +148,7 @@
             uid: string;
             type?: string;
             task: TaskType;
+            taskRun: TaskRun
         };
         executionId?: string;
         color?: string;
@@ -161,6 +162,7 @@
     }
 
     interface TaskRun {
+        id: string
         taskId: string;
         state: {
             current: [string, string]; // [state, stateText]
@@ -303,7 +305,7 @@
                     id: subflowIdContainer.flowId,
                     executionId: taskExecution.value?.taskRunList
                         .filter((taskRun: TaskRun) => 
-                            taskRun.taskId === props.data.node.task.id && 
+                            taskRun.id === props.data.node.taskRun.id && 
                             taskRun.outputs?.executionId
                         )
                         ?.[0]?.outputs?.executionId


### PR DESCRIPTION
What changes are being made and why?

For https://github.com/kestra-io/kestra/issues/10864

Made a change to use taskRun.id to match the node's taskRun id instead of taskId which is just a string like "subflow" and is the same for all subflows. The taskRun.id extract the correct run leading to correct linking of the execution id. 

Adding relevant screenshots for the same 

<img width="508" height="303" alt="Screenshot 2025-10-03 at 5 51 21 PM" src="https://github.com/user-attachments/assets/035b499f-b874-4948-9c07-9c43d1e82907" />
<img width="471" height="300" alt="Screenshot 2025-10-03 at 5 50 30 PM" src="https://github.com/user-attachments/assets/5e01ba90-accb-4d3c-9a8c-70d05feb90de" />

Testing the same using the flow mentioned in the issue. Attaching recording for the same 


https://github.com/user-attachments/assets/6abe938a-3ab3-4586-b92c-e5e18caaf4cc


