### PR TITLE
fix(ui): add native tooltip fallback for truncated task IDs

### DIFF
--- a/src/components/nodes/BasicNode.vue
+++ b/src/components/nodes/BasicNode.vue
@@ -13,7 +13,7 @@
             <div class="node-content">
                 <div class="d-flex node-title">
                     <div
-                        class="text-truncate task-title"
+                        class="text-truncate task-title" :title="hoverTooltip"
                     >
                         <tooltip :title="hoverTooltip">
                             {{ displayTitle }}


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra/issues/15394.

### ✨ Description

Fixes UX issue where long task IDs are truncated in topology nodes.

- Adds native `title` attribute as fallback tooltip
- Ensures full task ID is always accessible on hover

### 🧪 Testing

- Created task with long ID
- Verified truncation still occurs
- Verified tooltip shows full ID

### 📸 Screenshot
<img width="960" height="527" alt="Screenshot 2026-04-09 221400" src="https://github.com/user-attachments/assets/9fb4f2eb-e678-404a-9e88-721d96fa9018" />
