### PR TITLE
feat(topology): pluggable custom action button on task nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -477,6 +476,7 @@
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1802,7 +1802,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2464,7 +2463,6 @@
       "integrity": "sha512-fxnv76RddUYVjdNYIiStWdJAexqEikzpV7BDsa54VrY2vkOEWQ2xAIDx3jgC3o42PyaixPNtDK1I5RZNF4Porg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "type-fest": "~2.19",
@@ -2617,7 +2615,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/bootstrap": {
       "version": "5.2.10",
@@ -3028,7 +3027,8 @@
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
       "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -3065,7 +3065,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3841,6 +3840,7 @@
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.29.tgz",
       "integrity": "sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/shared": "3.5.29"
       }
@@ -3850,6 +3850,7 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.29.tgz",
       "integrity": "sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.29",
         "@vue/shared": "3.5.29"
@@ -3860,6 +3861,7 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.29.tgz",
       "integrity": "sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.29",
         "@vue/runtime-core": "3.5.29",
@@ -3872,6 +3874,7 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.29.tgz",
       "integrity": "sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.29",
         "@vue/shared": "3.5.29"
@@ -3891,6 +3894,7 @@
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
       "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
         "@vueuse/metadata": "10.11.1",
@@ -3907,6 +3911,7 @@
       "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
         "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -3932,6 +3937,7 @@
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
       "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -3941,6 +3947,7 @@
       "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
       "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "vue-demi": ">=0.14.8"
       },
@@ -3954,6 +3961,7 @@
       "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
         "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -3979,7 +3987,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4051,7 +4058,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -4280,7 +4288,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4540,7 +4547,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
       "integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.1",
         "@chevrotain/gast": "11.1.1",
@@ -4804,14 +4810,14 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cytoscape": {
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5212,7 +5218,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5504,7 +5509,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.3",
@@ -5634,7 +5640,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5699,7 +5704,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6209,6 +6213,7 @@
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
       "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15"
       }
@@ -7299,6 +7304,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7334,7 +7340,6 @@
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -8780,6 +8785,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8795,6 +8801,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9003,7 +9010,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9014,7 +9020,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9027,7 +9032,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -9375,7 +9381,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9732,7 +9737,6 @@
       "integrity": "sha512-eT4266OqLdRE3J/pxl2dk36Rnj9vv17Y6rNMpzxohOMjRVONyKkozUd6gaZ2C4WUcwYdIw6VE+ft4LwrJXt/4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -10043,7 +10047,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10424,7 +10427,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10500,7 +10502,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11148,7 +11149,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/components/misc/ExecutionInformations.vue
+++ b/src/components/misc/ExecutionInformations.vue
@@ -26,7 +26,7 @@
             taskRunList: any[];
         };
         task: {
-            type: object;
+            type: string;
             default: null;
         };
         state: string;

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -72,6 +72,16 @@
                 </tooltip>
             </span>
             <span
+                v-if="customAction && data.node.task"
+                class="circle-button"
+                :class="[`bg-${color}`]"
+                @click="emit(EVENTS.SHOW_CUSTOM_ACTION, {task: data.node.task, customAction: customAction})"
+            >
+                <tooltip :title="customAction.label">
+                    <Eye class="button-icon" :alt="customAction.label" />
+                </tooltip>
+            </span>
+            <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
                 :class="[`bg-${color}`]"
@@ -131,6 +141,7 @@
     import AlertIcon from "vue-material-design-icons/Alert.vue";
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
+    import Eye from "vue-material-design-icons/Eye.vue";
 
     // Define types
     interface TaskType {
@@ -190,12 +201,14 @@
         enableSubflowInteraction?: boolean;
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
+        customActions?: Record<string, { label: string; taskProp: string; lang: string }>;
     }>(), {
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
         enableSubflowInteraction: true,
         icons: undefined,
         iconComponent: undefined,
+        customActions: () => ({}),
     });
 
     defineOptions({
@@ -217,6 +230,7 @@
         (event: typeof EVENTS.SHOW_CONDITION, data: any) :void;
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
+        (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: { label: string; taskProp: string; lang: string } }) :void;
     }>();
 
     // Inject dependencies
@@ -316,6 +330,12 @@
             };
         }
         return props.data;
+    });
+
+    const customAction = computed(() => {
+        const taskType = props.data.node.task?.type as string | undefined;
+        if (!taskType || !props.customActions) return undefined;
+        return props.customActions[taskType];
     });
 
     const iconAlt = computed(() => {

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -71,16 +71,18 @@
                     <TextBoxSearch class="button-icon" alt="Show logs" />
                 </tooltip>
             </span>
-            <span
+            <button
                 v-if="customAction && data.node.task"
+                type="button"
                 class="circle-button"
                 :class="[`bg-${color}`]"
+                :aria-label="customAction.label"
                 @click="emit(EVENTS.SHOW_CUSTOM_ACTION, {task: data.node.task, customAction: customAction})"
             >
                 <tooltip :title="customAction.label">
                     <Eye class="button-icon" :alt="customAction.label" />
                 </tooltip>
-            </span>
+            </button>
             <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
@@ -120,7 +122,7 @@
     import {computed, inject} from "vue";
     import {Handle, Position} from "@vue-flow/core";
     import State from "../../utils/state";
-    import {EVENTS, SECTIONS} from "../../utils/constants";
+    import {CustomActionConfig, EVENTS, SECTIONS} from "../../utils/constants";
     import ExecutionInformations from "../misc/ExecutionInformations.vue";
     import Tooltip from "../misc/Tooltip.vue";
     import Utils from "../../utils/Utils";
@@ -201,7 +203,7 @@
         enableSubflowInteraction?: boolean;
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
-        customActions?: Record<string, { label: string; taskProp: string; lang: string }>;
+        customActions?: Record<string, CustomActionConfig>;
     }>(), {
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
@@ -230,7 +232,7 @@
         (event: typeof EVENTS.SHOW_CONDITION, data: any) :void;
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
-        (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: { label: string; taskProp: string; lang: string } }) :void;
+        (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
     }>();
 
     // Inject dependencies

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -146,7 +146,7 @@
     // Define types
     interface TaskType {
         id: string;
-        type: object;
+        type: string;
         default: null;
         runIf?: unknown;
         subflowId?: {

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -30,6 +30,7 @@
                 :icon-component="iconComponent"
                 :playground-enabled="playgroundEnabled"
                 :playground-ready-to-start="playgroundReadyToStart"
+                :custom-actions="customActions"
                 @edit="emit(EVENTS.EDIT, $event)"
                 @delete="emit(EVENTS.DELETE, $event)"
                 @run-task="emit(EVENTS.RUN_TASK, $event)"
@@ -38,6 +39,7 @@
                 @show-logs="emit(EVENTS.SHOW_LOGS, $event)"
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
+                @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"
@@ -154,6 +156,7 @@
         playgroundEnabled?: boolean;
         playgroundReadyToStart?: boolean;
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
+        customActions?: Record<string, { label: string; taskProp: string; lang: string }>;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,
@@ -169,7 +172,8 @@
         playgroundEnabled: false,
         playgroundReadyToStart: false,
         subflowsExecutions: () => ({}),
-        getNodeDimensions: undefined
+        getNodeDimensions: undefined,
+        customActions: () => ({})
     });
 
     const dragging = ref(false);
@@ -201,7 +205,8 @@
             "swapped-task",
             "message",
             "expand-subflow",
-            EVENTS.SHOW_CONDITION
+            EVENTS.SHOW_CONDITION,
+            EVENTS.SHOW_CUSTOM_ACTION
         ]
     )
 

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -129,7 +129,7 @@
     import SplitCellsHorizontal from "../../assets/icons/SplitCellsHorizontal.vue";
     import Download from "vue-material-design-icons/Download.vue";
     import {cssVariable} from "../../utils/global";
-    import {CLUSTER_PREFIX, EVENTS} from "../../utils/constants"
+    import {CLUSTER_PREFIX, CustomActionConfig, EVENTS} from "../../utils/constants"
     import Utils from "../../utils/Utils"
     import * as VueFlowUtils from "../../utils/VueFlowUtils";
     import {isParentChildrenRelation, swapBlocks} from "../../utils/FlowYamlUtils";
@@ -156,7 +156,7 @@
         playgroundEnabled?: boolean;
         playgroundReadyToStart?: boolean;
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
-        customActions?: Record<string, { label: string; taskProp: string; lang: string }>;
+        customActions?: Record<string, CustomActionConfig>;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -1,5 +1,12 @@
 @import "../../scss/color-palette";
 
+button.circle-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  appearance: none;
+}
+
 .circle-button {
     border-radius: 1rem;
     width: 1rem;

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -9,6 +9,7 @@
     align-items: center;
     margin-left: 0.25rem;
     z-index: 2000;
+    cursor: pointer;
 }
 
 $node-colors: (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,6 +19,7 @@ export const EVENTS = {
   EXPAND_DEPENDENCIES: "expandDependencies",
   SHOW_CONDITION: "showCondition",
   RUN_TASK: "runTask",
+  SHOW_CUSTOM_ACTION: "showCustomAction",
 } as const;
 
 export const CLUSTER_PREFIX = "cluster_";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -22,6 +22,12 @@ export const EVENTS = {
   SHOW_CUSTOM_ACTION: "showCustomAction",
 } as const;
 
+export interface CustomActionConfig {
+    label: string;
+    taskProp: string;
+    lang: string;
+}
+
 export const CLUSTER_PREFIX = "cluster_";
 
 export const NODE_SIZES = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,9 +23,9 @@ export const EVENTS = {
 } as const;
 
 export interface CustomActionConfig {
-    label: string;
-    taskProp: string;
-    lang: string;
+  label: string;
+  taskProp: string;
+  lang: string;
 }
 
 export const CLUSTER_PREFIX = "cluster_";

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -352,7 +352,7 @@ export const CustomAction = lodash.merge({},
             },
         },
         argTypes: {
-            onShowCustomAction: { action: "showCustomAction" },
+            onShowCustomAction: {action: "showCustomAction"},
         },
         loaders: [
             async () => ({

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -334,6 +334,35 @@ export const CustomNodes = lodash.merge({},
 
 import NodeDetailsData from "../../data/graphs/node-details.js";
 
+export const CustomAction = lodash.merge({},
+    base,
+    {
+        args: {
+            customActions: {
+                "io.kestra.plugin.jdbc.clickhouse.BulkInsert": {
+                    label: "View SQL Config",
+                    taskProp: "sql",
+                    lang: "sql",
+                },
+                "io.kestra.plugin.azure.datafactory.CreateRun": {
+                    label: "View Pipeline Config",
+                    taskProp: "pipelineName",
+                    lang: "yaml",
+                },
+            },
+        },
+        argTypes: {
+            onShowCustomAction: { action: "showCustomAction" },
+        },
+        loaders: [
+            async () => ({
+                flowGraph: NodeDetailsData,
+                source: "",
+            }),
+        ],
+    }
+)
+
 export const NodeDetails = lodash.merge({},
     base,
     {


### PR DESCRIPTION
## Summary

- Adds a new `SHOW_CUSTOM_ACTION` event constant to `EVENTS`
- `TaskNode` accepts a `customActions` prop (map of task type → `{ label, taskProp, lang }`); when the current node's task type has an entry, an eye-icon circular button renders alongside the existing logs/condition buttons and emits `showCustomAction`
- `Topology` forwards the `customActions` prop to `TaskNode` and relays the new event up to the parent

## Usage

Plugins declare a `customAction` in their topology-details `additionalProperties`:

```ts
additionalProperties: {
  "customAction": { "label": "Show SQL", "taskProp": "sql", "lang": "sql" }
}
```

The host app (e.g. `LowCodeEditor`) receives the `@show-custom-action` event with `{ task, customAction }` and can open a drawer to display the relevant task property.

## Test plan

- [ ] Task node with a matching `customActions` entry shows the eye button
- [ ] Task node without a matching entry shows no extra button
- [ ] Clicking the button emits `showCustomAction` with the correct task and customAction metadata
- [ ] Button tooltip shows the configured label (e.g. "Show SQL")

part-of: https://github.com/kestra-io/kestra/issues/12696