### PR TITLE
feat(topology): global toggle to show/hide extra metadata rows

### DIFF
--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -17,14 +17,14 @@
             <Transition name="details-slide">
                 <div v-if="globalShowExtraDetails" class="details-wrapper">
                     <slot name="details" />
-                    <div v-if="showDetailsConfig && data.node.task" class="view-details-action">
+                    <div v-if="actionConfig && data.node.task" class="view-details-action">
                         <button
                             type="button"
                             class="view-details-button"
-                            :aria-label="showDetailsConfig.label"
-                            @click="emit(EVENTS.SHOW_DETAILS, {task: data.node.task, showDetails: showDetailsConfig})"
+                            aria-label="Show details"
+                            @click="onShowDetails()"
                         >
-                            {{ showDetailsConfig.label }}
+                            Show details
                         </button>
                     </div>
                 </div>
@@ -205,6 +205,7 @@
         enableSubflowInteraction?: boolean;
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
+        customActions?: Record<string, ShowDetailsConfig>;
         showDetails?: Record<string, ShowDetailsConfig>;
     }>(), {
         sourcePosition: Position.Right,
@@ -212,6 +213,7 @@
         enableSubflowInteraction: true,
         icons: undefined,
         iconComponent: undefined,
+        customActions: () => ({}),
         showDetails: () => ({}),
     });
 
@@ -236,6 +238,7 @@
         (event: typeof EVENTS.SHOW_CONDITION, data: any) :void;
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
+        (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: ShowDetailsConfig }) :void;
         (event: typeof EVENTS.SHOW_DETAILS, data: { task: any; showDetails: ShowDetailsConfig }) :void;
     }>();
 
@@ -338,11 +341,41 @@
         return props.data;
     });
 
-    const showDetailsConfig = computed(() => {
+    const actionConfig = computed(() => {
         const taskType = props.data.node.task?.type as string | undefined;
-        if (!taskType || !props.showDetails) return undefined;
-        return props.showDetails[taskType];
+        if (!taskType) return undefined;
+
+        const customAction = props.customActions?.[taskType];
+        if (customAction) {
+            return {config: customAction, eventName: EVENTS.SHOW_CUSTOM_ACTION} as const;
+        }
+
+        const showDetails = props.showDetails?.[taskType];
+        if (showDetails) {
+            return {config: showDetails, eventName: EVENTS.SHOW_DETAILS} as const;
+        }
+
+        return undefined;
     });
+
+    function onShowDetails() {
+        if (!actionConfig.value) {
+            return;
+        }
+
+        if (actionConfig.value.eventName === EVENTS.SHOW_CUSTOM_ACTION) {
+            emit(EVENTS.SHOW_CUSTOM_ACTION, {
+                task: props.data.node.task,
+                customAction: actionConfig.value.config
+            });
+            return;
+        }
+
+        emit(EVENTS.SHOW_DETAILS, {
+            task: props.data.node.task,
+            showDetails: actionConfig.value.config
+        });
+    }
 
     const iconAlt = computed(() => {
         if(state.value === State.RUNNING){
@@ -391,21 +424,42 @@ button.playground-button,
 .view-details-action {
     display: flex;
     justify-content: flex-end;
-    margin-top: 4px;
-    padding: 0 6px 6px;
+    margin-top: 6px;
+    padding: 0 8px 8px;
 }
 
 .view-details-button {
-    font-size: 0.625rem;
-    padding: 2px 10px;
-    border-radius: 4px;
-    border: none;
-    background-color: var(--ks-background-secondary);
-    color: var(--ks-content-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    max-width: 100%;
+    box-sizing: border-box;
+    appearance: none;
+    margin: 0;
+    padding: 4px 10px;
+    border: 1px solid var(--ks-border-primary);
+    border-radius: 999px;
+    background-color: var(--ks-background-card);
+    color: var(--ks-content-secondary);
     cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1.2;
+    white-space: nowrap;
+    text-transform: none;
+    box-shadow: none;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 
     &:hover {
-        background-color: var(--ks-background-tertiary);
+        border-color: var(--ks-content-link);
+        background-color: var(--ks-background-secondary);
+        color: var(--ks-content-link);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--ks-content-link);
+        outline-offset: 2px;
     }
 }
 

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -13,8 +13,12 @@
         @mouseover="emit(EVENTS.MOUSE_OVER, $event)"
         @mouseleave="emit(EVENTS.MOUSE_LEAVE)"
     >
-        <template v-if="showExtraDetails" #details>
-            <slot name="details" />
+        <template #details>
+            <Transition name="details-slide">
+                <div v-if="showExtraDetails" class="details-wrapper">
+                    <slot name="details" />
+                </div>
+            </Transition>
         </template>
         <template #content>
             <execution-informations 
@@ -399,7 +403,20 @@
 
 button.playground-button,
 .dark button.playground-button {
-    color: _color-palette.$base-white; 
+    color: _color-palette.$base-white;
     background-color: _color-palette.$base-blue-400;
+}
+
+.details-slide-enter-active,
+.details-slide-leave-active {
+    transition: max-height 0.25s ease, opacity 0.25s ease;
+    overflow: hidden;
+    max-height: 200px;
+}
+
+.details-slide-enter-from,
+.details-slide-leave-to {
+    max-height: 0;
+    opacity: 0;
 }
 </style>

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -92,7 +92,7 @@
                 class="circle-button"
                 :class="[`bg-${color}`]"
                 :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
-                @click="emit(EVENTS.TOGGLE_EXTRA_DETAILS)"
+                @click="showExtraDetails = !showExtraDetails"
             >
                 <tooltip :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
                     <ChevronDown v-if="showExtraDetails" class="button-icon" alt="Hide extra details" />
@@ -135,7 +135,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, inject} from "vue";
+    import {computed, inject, ref, watch} from "vue";
     import {Handle, Position} from "@vue-flow/core";
     import State from "../../utils/state";
     import {CustomActionConfig, EVENTS, SECTIONS} from "../../utils/constants";
@@ -146,6 +146,7 @@
     import {
         EXECUTION_INJECTION_KEY,
         SUBFLOWS_EXECUTIONS_INJECTION_KEY,
+        SHOW_EXTRA_DETAILS_INJECTION_KEY,
     } from "../topology/injectionKeys";
 
     import Pencil from "vue-material-design-icons/Pencil.vue";
@@ -222,7 +223,6 @@
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
         customActions?: Record<string, CustomActionConfig>;
-        showExtraDetails?: boolean;
     }>(), {
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
@@ -230,7 +230,6 @@
         icons: undefined,
         iconComponent: undefined,
         customActions: () => ({}),
-        showExtraDetails: true,
     });
 
 
@@ -255,12 +254,16 @@
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
         (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
-        (event: typeof EVENTS.TOGGLE_EXTRA_DETAILS): void;
     }>();
 
     // Inject dependencies
     const execution = inject(EXECUTION_INJECTION_KEY);
     const subflowsExecutions = inject(SUBFLOWS_EXECUTIONS_INJECTION_KEY);
+    const globalShowExtraDetails = inject(SHOW_EXTRA_DETAILS_INJECTION_KEY);
+    const showExtraDetails = ref(globalShowExtraDetails?.value ?? true);
+    watch(() => globalShowExtraDetails?.value, (val) => {
+        if (val !== undefined) showExtraDetails.value = val;
+    });
 
     // Computed properties
     const color = computed(() => props.data.color ?? "primary");

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -392,10 +392,11 @@ button.playground-button,
     display: flex;
     justify-content: flex-end;
     margin-top: 4px;
+    padding: 0 6px 6px;
 }
 
 .view-details-button {
-    font-size: 0.75rem;
+    font-size: 0.625rem;
     padding: 2px 10px;
     border-radius: 4px;
     border: none;

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -17,6 +17,16 @@
             <Transition name="details-slide">
                 <div v-if="globalShowExtraDetails" class="details-wrapper">
                     <slot name="details" />
+                    <div v-if="customAction && data.node.task" class="view-details-action">
+                        <button
+                            type="button"
+                            class="view-details-button"
+                            :aria-label="customAction.label"
+                            @click="emit(EVENTS.SHOW_CUSTOM_ACTION, {task: data.node.task, customAction: customAction})"
+                        >
+                            {{ customAction.label }}
+                        </button>
+                    </div>
                 </div>
             </Transition>
         </template>
@@ -75,18 +85,6 @@
                     <TextBoxSearch class="button-icon" alt="Show logs" />
                 </tooltip>
             </span>
-            <button
-                v-if="customAction && data.node.task"
-                type="button"
-                class="circle-button"
-                :class="[`bg-${color}`]"
-                :aria-label="customAction.label"
-                @click="emit(EVENTS.SHOW_CUSTOM_ACTION, {task: data.node.task, customAction: customAction})"
-            >
-                <tooltip :title="customAction.label">
-                    <Eye class="button-icon" :alt="customAction.label" />
-                </tooltip>
-            </button>
             <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
@@ -148,7 +146,6 @@
     import AlertIcon from "vue-material-design-icons/Alert.vue";
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
-    import Eye from "vue-material-design-icons/Eye.vue";
 
     // Define types
     interface TaskType {
@@ -389,6 +386,26 @@ button.playground-button,
 .dark button.playground-button {
     color: _color-palette.$base-white;
     background-color: _color-palette.$base-blue-400;
+}
+
+.view-details-action {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+
+.view-details-button {
+    font-size: 0.75rem;
+    padding: 2px 10px;
+    border-radius: 4px;
+    border: none;
+    background-color: var(--ks-background-secondary);
+    color: var(--ks-content-primary);
+    cursor: pointer;
+
+    &:hover {
+        background-color: var(--ks-background-tertiary);
+    }
 }
 
 .details-slide-enter-active,

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -83,19 +83,7 @@
                     <Eye class="button-icon" :alt="customAction.label" />
                 </tooltip>
             </button>
-            <button
-                type="button"
-                class="circle-button"
-                :class="[`bg-${color}`]"
-                :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
-                @click="emit(EVENTS.TOGGLE_EXTRA_DETAILS)"
-            >
-                <tooltip :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
-                    <ChevronDown v-if="showExtraDetails" class="button-icon" alt="Hide extra details" />
-                    <ChevronUp v-else class="button-icon" alt="Show extra details" />
-                </tooltip>
-            </button>
-            <span
+<span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
                 :class="[`bg-${color}`]"
@@ -156,8 +144,6 @@
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
     import Eye from "vue-material-design-icons/Eye.vue";
-    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
-    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
 
     // Define types
     interface TaskType {
@@ -229,6 +215,8 @@
         showExtraDetails: true,
     });
 
+
+
     defineOptions({
         name: "TaskNode",
         inheritAttrs: false
@@ -249,7 +237,6 @@
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
         (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
-        (event: typeof EVENTS.TOGGLE_EXTRA_DETAILS): void;
     }>();
 
     // Inject dependencies

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -15,7 +15,7 @@
     >
         <template #details>
             <Transition name="details-slide">
-                <div v-if="showExtraDetails" class="details-wrapper">
+                <div v-if="globalShowExtraDetails" class="details-wrapper">
                     <slot name="details" />
                 </div>
             </Transition>
@@ -87,19 +87,6 @@
                     <Eye class="button-icon" :alt="customAction.label" />
                 </tooltip>
             </button>
-            <button
-                type="button"
-                class="circle-button"
-                :class="[`bg-${color}`]"
-                v-if="globalShowExtraDetails"
-                :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
-                @click="showExtraDetails = !showExtraDetails"
-            >
-                <tooltip :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
-                    <ChevronDown v-if="showExtraDetails" class="button-icon" alt="Hide extra details" />
-                    <ChevronUp v-else class="button-icon" alt="Show extra details" />
-                </tooltip>
-            </button>
             <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
@@ -136,7 +123,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, inject, ref, watch} from "vue";
+    import {computed, inject} from "vue";
     import {Handle, Position} from "@vue-flow/core";
     import State from "../../utils/state";
     import {CustomActionConfig, EVENTS, SECTIONS} from "../../utils/constants";
@@ -162,8 +149,6 @@
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
     import Eye from "vue-material-design-icons/Eye.vue";
-    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
-    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
 
     // Define types
     interface TaskType {
@@ -261,11 +246,6 @@
     const execution = inject(EXECUTION_INJECTION_KEY);
     const subflowsExecutions = inject(SUBFLOWS_EXECUTIONS_INJECTION_KEY);
     const globalShowExtraDetails = inject(SHOW_EXTRA_DETAILS_INJECTION_KEY);
-    const showExtraDetails = ref(globalShowExtraDetails?.value ?? false);
-    watch(() => globalShowExtraDetails?.value, (val) => {
-        if (val !== undefined) showExtraDetails.value = val;
-    });
-
     // Computed properties
     const color = computed(() => props.data.color ?? "primary");
 

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -13,7 +13,7 @@
         @mouseover="emit(EVENTS.MOUSE_OVER, $event)"
         @mouseleave="emit(EVENTS.MOUSE_LEAVE)"
     >
-        <template #details>
+        <template v-if="showExtraDetails" #details>
             <slot name="details" />
         </template>
         <template #content>
@@ -83,6 +83,18 @@
                     <Eye class="button-icon" :alt="customAction.label" />
                 </tooltip>
             </button>
+            <button
+                type="button"
+                class="circle-button"
+                :class="[`bg-${color}`]"
+                :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
+                @click="emit(EVENTS.TOGGLE_EXTRA_DETAILS)"
+            >
+                <tooltip :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
+                    <ChevronDown v-if="showExtraDetails" class="button-icon" alt="Hide extra details" />
+                    <ChevronUp v-else class="button-icon" alt="Show extra details" />
+                </tooltip>
+            </button>
             <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
@@ -144,6 +156,8 @@
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
     import Eye from "vue-material-design-icons/Eye.vue";
+    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
+    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
 
     // Define types
     interface TaskType {
@@ -204,6 +218,7 @@
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
         customActions?: Record<string, CustomActionConfig>;
+        showExtraDetails?: boolean;
     }>(), {
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
@@ -211,6 +226,7 @@
         icons: undefined,
         iconComponent: undefined,
         customActions: () => ({}),
+        showExtraDetails: true,
     });
 
     defineOptions({
@@ -233,6 +249,7 @@
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
         (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
+        (event: typeof EVENTS.TOGGLE_EXTRA_DETAILS): void;
     }>();
 
     // Inject dependencies

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -17,14 +17,14 @@
             <Transition name="details-slide">
                 <div v-if="globalShowExtraDetails" class="details-wrapper">
                     <slot name="details" />
-                    <div v-if="customAction && data.node.task" class="view-details-action">
+                    <div v-if="showDetailsConfig && data.node.task" class="view-details-action">
                         <button
                             type="button"
                             class="view-details-button"
-                            :aria-label="customAction.label"
-                            @click="emit(EVENTS.SHOW_CUSTOM_ACTION, {task: data.node.task, customAction: customAction})"
+                            :aria-label="showDetailsConfig.label"
+                            @click="emit(EVENTS.SHOW_DETAILS, {task: data.node.task, showDetails: showDetailsConfig})"
                         >
-                            {{ customAction.label }}
+                            {{ showDetailsConfig.label }}
                         </button>
                     </div>
                 </div>
@@ -124,7 +124,7 @@
     import {computed, inject} from "vue";
     import {Handle, Position} from "@vue-flow/core";
     import State from "../../utils/state";
-    import {CustomActionConfig, EVENTS, SECTIONS} from "../../utils/constants";
+    import {ShowDetailsConfig, EVENTS, SECTIONS} from "../../utils/constants";
     import ExecutionInformations from "../misc/ExecutionInformations.vue";
     import Tooltip from "../misc/Tooltip.vue";
     import Utils from "../../utils/Utils";
@@ -205,14 +205,14 @@
         enableSubflowInteraction?: boolean;
         playgroundEnabled: boolean;
         playgroundReadyToStart: boolean;
-        customActions?: Record<string, CustomActionConfig>;
+        showDetails?: Record<string, ShowDetailsConfig>;
     }>(), {
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
         enableSubflowInteraction: true,
         icons: undefined,
         iconComponent: undefined,
-        customActions: () => ({}),
+        showDetails: () => ({}),
     });
 
 
@@ -236,7 +236,7 @@
         (event: typeof EVENTS.SHOW_CONDITION, data: any) :void;
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
-        (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
+        (event: typeof EVENTS.SHOW_DETAILS, data: { task: any; showDetails: ShowDetailsConfig }) :void;
     }>();
 
     // Inject dependencies
@@ -338,10 +338,10 @@
         return props.data;
     });
 
-    const customAction = computed(() => {
+    const showDetailsConfig = computed(() => {
         const taskType = props.data.node.task?.type as string | undefined;
-        if (!taskType || !props.customActions) return undefined;
-        return props.customActions[taskType];
+        if (!taskType || !props.showDetails) return undefined;
+        return props.showDetails[taskType];
     });
 
     const iconAlt = computed(() => {

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -91,6 +91,7 @@
                 type="button"
                 class="circle-button"
                 :class="[`bg-${color}`]"
+                v-if="globalShowExtraDetails"
                 :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
                 @click="showExtraDetails = !showExtraDetails"
             >
@@ -260,7 +261,7 @@
     const execution = inject(EXECUTION_INJECTION_KEY);
     const subflowsExecutions = inject(SUBFLOWS_EXECUTIONS_INJECTION_KEY);
     const globalShowExtraDetails = inject(SHOW_EXTRA_DETAILS_INJECTION_KEY);
-    const showExtraDetails = ref(globalShowExtraDetails?.value ?? true);
+    const showExtraDetails = ref(globalShowExtraDetails?.value ?? false);
     watch(() => globalShowExtraDetails?.value, (val) => {
         if (val !== undefined) showExtraDetails.value = val;
     });

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -32,7 +32,7 @@
         </template>
         <template #content>
             <execution-informations 
-                v-if="taskExecution"
+                v-if="taskExecution && globalShowExtraDetails"
                 :execution="taskExecution"
                 :task="data.node.task"
                 :color="color"

--- a/src/components/nodes/TaskNode.vue
+++ b/src/components/nodes/TaskNode.vue
@@ -83,7 +83,19 @@
                     <Eye class="button-icon" :alt="customAction.label" />
                 </tooltip>
             </button>
-<span
+            <button
+                type="button"
+                class="circle-button"
+                :class="[`bg-${color}`]"
+                :aria-label="$t(showExtraDetails ? 'hide extra details' : 'show extra details')"
+                @click="emit(EVENTS.TOGGLE_EXTRA_DETAILS)"
+            >
+                <tooltip :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
+                    <ChevronDown v-if="showExtraDetails" class="button-icon" alt="Hide extra details" />
+                    <ChevronUp v-else class="button-icon" alt="Show extra details" />
+                </tooltip>
+            </button>
+            <span
                 v-if="!taskExecution && !data.isReadOnly && data.isFlowable"
                 class="circle-button"
                 :class="[`bg-${color}`]"
@@ -144,6 +156,8 @@
     import SkipForwardIcon from "vue-material-design-icons/SkipForward.vue";
     import RotatingDots from "../../assets/icons/RotatingDots.vue";
     import Eye from "vue-material-design-icons/Eye.vue";
+    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
+    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
 
     // Define types
     interface TaskType {
@@ -237,6 +251,7 @@
         (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
         (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
         (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
+        (event: typeof EVENTS.TOGGLE_EXTRA_DETAILS): void;
     }>();
 
     // Inject dependencies

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -91,7 +91,7 @@
 
         <Controls v-if="controlsShown" :show-interactive="false" :show-fit-view="false">
             <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails}">
-                <FitToScreen />
+                <Information />
             </ControlButton>
             <ControlButton @click="fitView()">
                 <svg viewBox="0 0 32 32" style="width:12px;height:12px"><path d="M3.692 4.63c0-.53.4-.938.939-.938h5.215V0H4.708C2.13 0 0 2.054 0 4.63v5.216h3.692V4.631zM27.354 0h-5.2v3.692h5.17c.53 0 .984.4.984.939v5.215H32V4.631A4.624 4.624 0 0 0 27.354 0zm.954 24.83c0 .532-.4.94-.939.94h-5.215v3.768h5.215c2.577 0 4.631-2.13 4.631-4.707v-5.139h-3.692v5.139zm-23.677.94a.919.919 0 0 1-.939-.94v-5.138H0v5.139c0 2.577 2.13 4.707 4.708 4.707h5.138V25.77H4.631z" fill="currentColor" /></svg>
@@ -134,7 +134,7 @@
     // @ts-expect-error no types for internals necessary
     import SplitCellsHorizontal from "../../assets/icons/SplitCellsHorizontal.vue";
     import Download from "vue-material-design-icons/Download.vue";
-    import FitToScreen from "vue-material-design-icons/FitToScreen.vue";
+    import Information from "vue-material-design-icons/Information.vue";
     import {cssVariable} from "../../utils/global";
     import {CLUSTER_PREFIX, CustomActionConfig, EVENTS} from "../../utils/constants"
     import Utils from "../../utils/Utils"
@@ -184,7 +184,7 @@
     });
 
     const dragging = ref(false);
-    const showExtraDetails = ref(true);
+    const showExtraDetails = ref(false);
     const lastPosition = ref<XYPosition | null>()
     const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow(props.id);
     const edgeReplacer = ref({});

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -41,7 +41,6 @@
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
                 @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
-                @toggle-extra-details="showExtraDetails = !showExtraDetails"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"
@@ -92,10 +91,14 @@
         </template>
 
         <Controls v-if="controlsShown" :show-interactive="false">
+            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
+                <ChevronUp v-if="showExtraDetails" />
+                <ChevronDown v-else />
+            </ControlButton>
             <ControlButton @click="emit('toggle-orientation', $event)" v-if="toggleOrientationButton">
                 <component :is="isHorizontal ? SplitCellsHorizontal : SplitCellsVertical" />
             </ControlButton>
-            <ControlButton @click="toggleDropdown"> 
+            <ControlButton @click="toggleDropdown">
                 <Download />
             </ControlButton>
             <ul v-if="isDropdownOpen" class="exporting">
@@ -130,6 +133,8 @@
     // @ts-expect-error no types for internals necessary
     import SplitCellsHorizontal from "../../assets/icons/SplitCellsHorizontal.vue";
     import Download from "vue-material-design-icons/Download.vue";
+    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
+    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
     import {cssVariable} from "../../utils/global";
     import {CLUSTER_PREFIX, CustomActionConfig, EVENTS} from "../../utils/constants"
     import Utils from "../../utils/Utils"

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -31,6 +31,7 @@
                 :playground-enabled="playgroundEnabled"
                 :playground-ready-to-start="playgroundReadyToStart"
                 :custom-actions="customActions"
+                :show-extra-details="showExtraDetails"
                 @edit="emit(EVENTS.EDIT, $event)"
                 @delete="emit(EVENTS.DELETE, $event)"
                 @run-task="emit(EVENTS.RUN_TASK, $event)"
@@ -40,6 +41,7 @@
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
                 @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
+                @toggle-extra-details="showExtraDetails = !showExtraDetails"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"
@@ -177,6 +179,7 @@
     });
 
     const dragging = ref(false);
+    const showExtraDetails = ref(true);
     const lastPosition = ref<XYPosition | null>()
     const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow(props.id);
     const edgeReplacer = ref({});

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -30,6 +30,7 @@
                 :icon-component="iconComponent"
                 :playground-enabled="playgroundEnabled"
                 :playground-ready-to-start="playgroundReadyToStart"
+                :custom-actions="customActions"
                 :show-details="showDetails"
                 @edit="emit(EVENTS.EDIT, $event)"
                 @delete="emit(EVENTS.DELETE, $event)"
@@ -39,6 +40,7 @@
                 @show-logs="emit(EVENTS.SHOW_LOGS, $event)"
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
+                @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
                 @show-details="emit(EVENTS.SHOW_DETAILS, $event)"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
@@ -136,7 +138,7 @@
     import Download from "vue-material-design-icons/Download.vue";
     import Information from "vue-material-design-icons/Information.vue";
     import {cssVariable} from "../../utils/global";
-    import {CLUSTER_PREFIX, EVENTS, ShowDetailsConfig} from "../../utils/constants"
+    import {CLUSTER_PREFIX, EVENTS, NODE_SIZES, ShowDetailsConfig} from "../../utils/constants"
     import Utils from "../../utils/Utils"
     import * as VueFlowUtils from "../../utils/VueFlowUtils";
     import {isParentChildrenRelation, swapBlocks} from "../../utils/FlowYamlUtils";
@@ -163,6 +165,7 @@
         playgroundEnabled?: boolean;
         playgroundReadyToStart?: boolean;
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
+        customActions?: Record<string, ShowDetailsConfig>;
         showDetails?: Record<string, ShowDetailsConfig>;
     }>(), {
         isHorizontal: true,
@@ -180,25 +183,47 @@
         playgroundReadyToStart: false,
         subflowsExecutions: () => ({}),
         getNodeDimensions: undefined,
+        customActions: () => ({}),
         showDetails: () => ({})
     });
 
     const dragging = ref(false);
     const showExtraDetails = ref(false);
+    const HOVERED_NODE_CLASS = "topology-node-hovered";
+    const DROP_TARGET_NODE_CLASS = "topology-node-drop-target";
     const effectiveGetNodeDimensions = computed(() => {
         return (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => {
+            const baseHeight = getNodeHeight(node);
             const dimensions = props.getNodeDimensions
                 ? props.getNodeDimensions(node, getNodeWidth, getNodeHeight)
                 : {
                     width: getNodeWidth(node),
-                    height: getNodeHeight(node)
+                    height: baseHeight
                 };
 
             if (!showExtraDetails.value && VueFlowUtils.isTaskNode(node)) {
                 return {
                     ...dimensions,
-                    height: getNodeHeight(node)
+                    height: baseHeight
                 };
+            }
+
+            if (showExtraDetails.value && VueFlowUtils.isTaskNode(node)) {
+                const taskType = node?.task?.type as string | undefined;
+                const hasDetailsAction = Boolean(
+                    (taskType && props.customActions?.[taskType]) ||
+                    (taskType && props.showDetails?.[taskType])
+                );
+
+                if (hasDetailsAction) {
+                    return {
+                        ...dimensions,
+                        height: Math.max(
+                            dimensions.height,
+                            NODE_SIZES.TASK_EXPANDED_FALLBACK_HEIGHT
+                        )
+                    };
+                }
             }
 
             return dimensions;
@@ -234,6 +259,7 @@
             "message",
             "expand-subflow",
             EVENTS.SHOW_CONDITION,
+            EVENTS.SHOW_CUSTOM_ACTION,
             EVENTS.SHOW_DETAILS
         ]
     )
@@ -298,8 +324,8 @@
         if (!dragging.value) {
             VueFlowUtils.linkedElements(props.id, node.uid).forEach((n) => {
                 if (n?.type === "task") {
-                    n.style = {...n.style, outline: "0.5px solid " + cssVariable("--bs-gray-900")}
-                    n.class = "rounded-3"
+                    n.style = {...n.style, opacity: "1", outline: "none"}
+                    setNodeInteractionClass(n, HOVERED_NODE_CLASS, true);
                 }
             });
         }
@@ -314,7 +340,7 @@
         getNodes.value.filter(n => n.type === "task" || n.type === "trigger")
             .forEach(n => {
                 n.style = {...n.style, opacity: "1", outline: "none"}
-                n.class = ""
+                clearNodeInteractionClasses(n);
             })
     }
 
@@ -384,14 +410,49 @@
         if (e.intersections && !checkIntersections(e.intersections, e.node) && e.intersections.filter((n:any) => n.type === "task").length === 1) {
             e.intersections.forEach((n:any) => {
                 if (n.type === "task") {
-                    n.style = {...n.style, outline: "0.5px solid " + cssVariable("--bs-primary")}
-                    n.class = "rounded-3"
+                    n.style = {...n.style, outline: "none"}
+                    setNodeInteractionClass(n, DROP_TARGET_NODE_CLASS, true);
                 }
             })
-            e.node.style = {...e.node.style, outline: "0.5px solid " + cssVariable("--bs-primary")}
-            e.node.class = "rounded-3"
+            e.node.style = {...e.node.style, outline: "none"}
+            setNodeInteractionClass(e.node, DROP_TARGET_NODE_CLASS, true);
         }
     })
+
+    const normalizeNodeClasses = (value: unknown): string[] => {
+        if (typeof value === "string") {
+            return value.split(/\s+/).filter(Boolean);
+        }
+
+        if (Array.isArray(value)) {
+            return value.flatMap((entry) => normalizeNodeClasses(entry));
+        }
+
+        if (value && typeof value === "object") {
+            return Object.entries(value as Record<string, boolean>)
+                .filter(([, enabled]) => Boolean(enabled))
+                .map(([className]) => className);
+        }
+
+        return [];
+    };
+
+    const setNodeInteractionClass = (node: any, className: string, enabled: boolean) => {
+        const classes = new Set(normalizeNodeClasses(node.class));
+
+        if (enabled) {
+            classes.add(className);
+        } else {
+            classes.delete(className);
+        }
+
+        node.class = Array.from(classes).join(" ");
+    };
+
+    const clearNodeInteractionClasses = (node: any) => {
+        setNodeInteractionClass(node, HOVERED_NODE_CLASS, false);
+        setNodeInteractionClass(node, DROP_TARGET_NODE_CLASS, false);
+    };
 
     const checkIntersections = (intersections:any, node:any) => {
         const tasksMeet = intersections.filter((n:any) => n.type === "task").map((n:any) => Utils.afterLastDot(n.id));

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -31,7 +31,6 @@
                 :playground-enabled="playgroundEnabled"
                 :playground-ready-to-start="playgroundReadyToStart"
                 :custom-actions="customActions"
-                :show-extra-details="showExtraDetails"
                 @edit="emit(EVENTS.EDIT, $event)"
                 @delete="emit(EVENTS.DELETE, $event)"
                 @run-task="emit(EVENTS.RUN_TASK, $event)"
@@ -41,7 +40,6 @@
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
                 @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
-                @toggle-extra-details="showExtraDetails = !showExtraDetails"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"
@@ -140,7 +138,7 @@
     import * as VueFlowUtils from "../../utils/VueFlowUtils";
     import {isParentChildrenRelation, swapBlocks} from "../../utils/FlowYamlUtils";
     import {useScreenshot} from "./export/useScreenshot";
-    import {EXECUTION_INJECTION_KEY, SUBFLOWS_EXECUTIONS_INJECTION_KEY} from "./injectionKeys";
+    import {EXECUTION_INJECTION_KEY, SUBFLOWS_EXECUTIONS_INJECTION_KEY, SHOW_EXTRA_DETAILS_INJECTION_KEY} from "./injectionKeys";
     import BasicNode from "../nodes/BasicNode.vue";
 
     const props = withDefaults(defineProps<{
@@ -194,6 +192,7 @@
 
     provide(EXECUTION_INJECTION_KEY, computed(() => props.execution));
     provide(SUBFLOWS_EXECUTIONS_INJECTION_KEY, computed(() => props.subflowsExecutions));
+    provide(SHOW_EXTRA_DETAILS_INJECTION_KEY, showExtraDetails);
 
 
     const emit = defineEmits(

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -90,7 +90,7 @@
         </template>
 
         <Controls v-if="controlsShown" :show-interactive="false" :show-fit-view="false">
-            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails}">
+            <ControlButton @click="showExtraDetails = !showExtraDetails" :class="{'active': showExtraDetails}">
                 <Information />
             </ControlButton>
             <ControlButton @click="fitView()">
@@ -185,6 +185,9 @@
 
     const dragging = ref(false);
     const showExtraDetails = ref(false);
+    const effectiveGetNodeDimensions = computed(() =>
+        showExtraDetails.value ? props.getNodeDimensions : undefined
+    );
     const lastPosition = ref<XYPosition | null>()
     const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow(props.id);
     const edgeReplacer = ref({});
@@ -232,6 +235,10 @@
         generateGraph();
     })
 
+    watch(showExtraDetails, () => {
+        generateGraph();
+    })
+
     const generateGraph = () => {
         VueFlowUtils.cleanGraph(props.id);
 
@@ -259,7 +266,7 @@
                 props.isReadOnly,
                 props.isAllowedEdit,
                 props.enableSubflowInteraction,
-                props.getNodeDimensions
+                effectiveGetNodeDimensions.value
             );
 
             if(elements) {

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -92,15 +92,14 @@
         </template>
 
         <Controls v-if="controlsShown" :show-interactive="false">
-            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')">
-                <ChevronUp v-if="showExtraDetails" />
-                <ChevronDown v-else />
-            </ControlButton>
             <ControlButton @click="emit('toggle-orientation', $event)" v-if="toggleOrientationButton">
                 <component :is="isHorizontal ? SplitCellsHorizontal : SplitCellsVertical" />
             </ControlButton>
             <ControlButton @click="toggleDropdown">
                 <Download />
+            </ControlButton>
+            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails}">
+                <FitToScreen />
             </ControlButton>
             <ul v-if="isDropdownOpen" class="exporting">
                 <li @click="exportAsImage('jpeg')" class="item">
@@ -134,8 +133,7 @@
     // @ts-expect-error no types for internals necessary
     import SplitCellsHorizontal from "../../assets/icons/SplitCellsHorizontal.vue";
     import Download from "vue-material-design-icons/Download.vue";
-    import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
-    import ChevronUp from "vue-material-design-icons/ChevronUp.vue";
+    import FitToScreen from "vue-material-design-icons/FitToScreen.vue";
     import {cssVariable} from "../../utils/global";
     import {CLUSTER_PREFIX, CustomActionConfig, EVENTS} from "../../utils/constants"
     import Utils from "../../utils/Utils"

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -212,7 +212,7 @@
                 const taskType = node?.task?.type as string | undefined;
                 const hasDetailsAction = Boolean(
                     (taskType && props.customActions?.[taskType]) ||
-                    (taskType && props.showDetails?.[taskType])
+                        (taskType && props.showDetails?.[taskType])
                 );
 
                 if (hasDetailsAction) {

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -30,7 +30,7 @@
                 :icon-component="iconComponent"
                 :playground-enabled="playgroundEnabled"
                 :playground-ready-to-start="playgroundReadyToStart"
-                :custom-actions="customActions"
+                :show-details="showDetails"
                 @edit="emit(EVENTS.EDIT, $event)"
                 @delete="emit(EVENTS.DELETE, $event)"
                 @run-task="emit(EVENTS.RUN_TASK, $event)"
@@ -39,7 +39,7 @@
                 @show-logs="emit(EVENTS.SHOW_LOGS, $event)"
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
-                @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
+                @show-details="emit(EVENTS.SHOW_DETAILS, $event)"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"
@@ -136,7 +136,7 @@
     import Download from "vue-material-design-icons/Download.vue";
     import Information from "vue-material-design-icons/Information.vue";
     import {cssVariable} from "../../utils/global";
-    import {CLUSTER_PREFIX, CustomActionConfig, EVENTS} from "../../utils/constants"
+    import {CLUSTER_PREFIX, EVENTS, ShowDetailsConfig} from "../../utils/constants"
     import Utils from "../../utils/Utils"
     import * as VueFlowUtils from "../../utils/VueFlowUtils";
     import {isParentChildrenRelation, swapBlocks} from "../../utils/FlowYamlUtils";
@@ -163,7 +163,7 @@
         playgroundEnabled?: boolean;
         playgroundReadyToStart?: boolean;
         getNodeDimensions?: (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => { width: number, height: number };
-        customActions?: Record<string, CustomActionConfig>;
+        showDetails?: Record<string, ShowDetailsConfig>;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,
@@ -180,7 +180,7 @@
         playgroundReadyToStart: false,
         subflowsExecutions: () => ({}),
         getNodeDimensions: undefined,
-        customActions: () => ({})
+        showDetails: () => ({})
     });
 
     const dragging = ref(false);
@@ -234,7 +234,7 @@
             "message",
             "expand-subflow",
             EVENTS.SHOW_CONDITION,
-            EVENTS.SHOW_CUSTOM_ACTION
+            EVENTS.SHOW_DETAILS
         ]
     )
 

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -96,7 +96,7 @@
             <ControlButton @click="toggleDropdown">
                 <Download />
             </ControlButton>
-            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails}">
+            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails, 'extra-details-toggle': true}">
                 <FitToScreen />
             </ControlButton>
             <ul v-if="isDropdownOpen" class="exporting">

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -41,6 +41,7 @@
                 @show-description="emit(EVENTS.SHOW_DESCRIPTION, $event)"
                 @show-condition="emit(EVENTS.SHOW_CONDITION, $event)"
                 @show-custom-action="emit(EVENTS.SHOW_CUSTOM_ACTION, $event)"
+                @toggle-extra-details="showExtraDetails = !showExtraDetails"
                 @mouseover="onMouseOver($event)"
                 @mouseleave="onMouseLeave()"
                 @add-error="emit('on-add-flowable-error', $event)"

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -89,15 +89,18 @@
             />
         </template>
 
-        <Controls v-if="controlsShown" :show-interactive="false">
+        <Controls v-if="controlsShown" :show-interactive="false" :show-fit-view="false">
+            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails}">
+                <FitToScreen />
+            </ControlButton>
+            <ControlButton @click="fitView()">
+                <svg viewBox="0 0 32 32" style="width:12px;height:12px"><path d="M3.692 4.63c0-.53.4-.938.939-.938h5.215V0H4.708C2.13 0 0 2.054 0 4.63v5.216h3.692V4.631zM27.354 0h-5.2v3.692h5.17c.53 0 .984.4.984.939v5.215H32V4.631A4.624 4.624 0 0 0 27.354 0zm.954 24.83c0 .532-.4.94-.939.94h-5.215v3.768h5.215c2.577 0 4.631-2.13 4.631-4.707v-5.139h-3.692v5.139zm-23.677.94a.919.919 0 0 1-.939-.94v-5.138H0v5.139c0 2.577 2.13 4.707 4.708 4.707h5.138V25.77H4.631z" fill="currentColor" /></svg>
+            </ControlButton>
             <ControlButton @click="emit('toggle-orientation', $event)" v-if="toggleOrientationButton">
                 <component :is="isHorizontal ? SplitCellsHorizontal : SplitCellsVertical" />
             </ControlButton>
             <ControlButton @click="toggleDropdown">
                 <Download />
-            </ControlButton>
-            <ControlButton @click="showExtraDetails = !showExtraDetails" :title="$t(showExtraDetails ? 'hide extra details' : 'show extra details')" :class="{'active': showExtraDetails, 'extra-details-toggle': true}">
-                <FitToScreen />
             </ControlButton>
             <ul v-if="isDropdownOpen" class="exporting">
                 <li @click="exportAsImage('jpeg')" class="item">

--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -185,9 +185,25 @@
 
     const dragging = ref(false);
     const showExtraDetails = ref(false);
-    const effectiveGetNodeDimensions = computed(() =>
-        showExtraDetails.value ? props.getNodeDimensions : undefined
-    );
+    const effectiveGetNodeDimensions = computed(() => {
+        return (node: any, getNodeWidth: (node: any) => number, getNodeHeight: (node: any) => number) => {
+            const dimensions = props.getNodeDimensions
+                ? props.getNodeDimensions(node, getNodeWidth, getNodeHeight)
+                : {
+                    width: getNodeWidth(node),
+                    height: getNodeHeight(node)
+                };
+
+            if (!showExtraDetails.value && VueFlowUtils.isTaskNode(node)) {
+                return {
+                    ...dimensions,
+                    height: getNodeHeight(node)
+                };
+            }
+
+            return dimensions;
+        };
+    });
     const lastPosition = ref<XYPosition | null>()
     const {getNodes, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, setElements, vueFlowRef} = useVueFlow(props.id);
     const edgeReplacer = ref({});

--- a/src/components/topology/injectionKeys.ts
+++ b/src/components/topology/injectionKeys.ts
@@ -1,4 +1,5 @@
-import type {ComputedRef, InjectionKey} from "vue"
+import type {ComputedRef, InjectionKey, Ref} from "vue"
 
 export const EXECUTION_INJECTION_KEY = Symbol("execution-injection-key") as InjectionKey<ComputedRef<any>>
 export const SUBFLOWS_EXECUTIONS_INJECTION_KEY = Symbol("subflows-executions-injection-key") as InjectionKey<ComputedRef<Record<string, any[]>>>
+export const SHOW_EXTRA_DETAILS_INJECTION_KEY = Symbol("show-extra-details-injection-key") as InjectionKey<Ref<boolean>>

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -34,6 +34,13 @@ $node-colors: (
 .vue-flow__controls {
     border: 1px solid var(--ks-border-primary);
     border-radius: var(--bs-border-radius);
+    display: flex;
+    flex-direction: column;
+
+    .vue-flow__controls-zoomin  { order: 1; }
+    .vue-flow__controls-zoomout { order: 2; }
+    .extra-details-toggle       { order: 3; }
+    .vue-flow__controls-fitview { order: 4; }
 }
 
 .vue-flow__controls-button {

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -34,13 +34,6 @@ $node-colors: (
 .vue-flow__controls {
     border: 1px solid var(--ks-border-primary);
     border-radius: var(--bs-border-radius);
-    display: flex;
-    flex-direction: column;
-
-    .vue-flow__controls-zoomin  { order: 1; }
-    .vue-flow__controls-zoomout { order: 2; }
-    .extra-details-toggle       { order: 3; }
-    .vue-flow__controls-fitview { order: 4; }
 }
 
 .vue-flow__controls-button {

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -83,6 +83,19 @@ $node-colors: (
 }
 
 .vue-flow__container {
+    .vue-flow__node.topology-node-hovered,
+    .vue-flow__node.topology-node-drop-target {
+        outline: none !important;
+    }
+
+    .vue-flow__node.topology-node-hovered .node-wrapper {
+        border-color: var(--bs-gray-900) !important;
+    }
+
+    .vue-flow__node.topology-node-drop-target .node-wrapper {
+        border-color: var(--bs-primary) !important;
+    }
+
     .top-button-div {
         position: absolute;
         top: -0.5rem;

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -40,6 +40,18 @@ $node-colors: (
     color: var(--bs-black);
     border-bottom-color: var(--bs-border-color);
 
+    .material-design-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
+
+        svg {
+            width: 12px;
+            height: 12px;
+        }
+    }
+
     svg {
         fill: var(--bs-black);
     }

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -44,12 +44,20 @@ $node-colors: (
         fill: var(--bs-black);
     }
 
+    &.active svg {
+        fill: var(--ks-content-link);
+    }
+
     html.dark & {
         background: var(--ks-background-card);
         color: var(--bs-white);
 
         svg {
             fill: var(--bs-white);
+        }
+
+        &.active svg {
+            fill: var(--ks-content-link);
         }
     }
 }

--- a/src/components/topology/topology.scss
+++ b/src/components/topology/topology.scss
@@ -31,6 +31,10 @@ $node-colors: (
     font-size: 0.66rem;
 }
 
+.vue-flow__panel.vue-flow__controls {
+    z-index: 200001;
+}
+
 .vue-flow__controls {
     border: 1px solid var(--ks-border-primary);
     border-radius: var(--bs-border-radius);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,6 +19,7 @@ export const EVENTS = {
   EXPAND_DEPENDENCIES: "expandDependencies",
   SHOW_CONDITION: "showCondition",
   RUN_TASK: "runTask",
+  SHOW_CUSTOM_ACTION: "showCustomAction",
   SHOW_DETAILS: "showDetails",
 } as const;
 
@@ -33,6 +34,7 @@ export const CLUSTER_PREFIX = "cluster_";
 export const NODE_SIZES = {
   TASK_WIDTH: 184,
   TASK_HEIGHT: 44,
+  TASK_EXPANDED_FALLBACK_HEIGHT: 140,
   TRIGGER_WIDTH: 184,
   TRIGGER_HEIGHT: 44,
   DOT_WIDTH: 5,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,10 +19,10 @@ export const EVENTS = {
   EXPAND_DEPENDENCIES: "expandDependencies",
   SHOW_CONDITION: "showCondition",
   RUN_TASK: "runTask",
-  SHOW_CUSTOM_ACTION: "showCustomAction",
+  SHOW_DETAILS: "showDetails",
 } as const;
 
-export interface CustomActionConfig {
+export interface ShowDetailsConfig {
   label: string;
   taskProp: string;
   lang: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,7 @@ export const EVENTS = {
   SHOW_CONDITION: "showCondition",
   RUN_TASK: "runTask",
   SHOW_CUSTOM_ACTION: "showCustomAction",
+  TOGGLE_EXTRA_DETAILS: "toggleExtraDetails",
 } as const;
 
 export interface CustomActionConfig {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,7 +20,6 @@ export const EVENTS = {
   SHOW_CONDITION: "showCondition",
   RUN_TASK: "runTask",
   SHOW_CUSTOM_ACTION: "showCustomAction",
-  TOGGLE_EXTRA_DETAILS: "toggleExtraDetails",
 } as const;
 
 export interface CustomActionConfig {

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -335,11 +335,11 @@ export const CustomNodes = lodash.merge({},
 import NodeDetailsData from "../../data/graphs/node-details.js";
 import ExtraDetailsData from "../../data/graphs/extra-details.js";
 
-export const CustomAction = lodash.merge({},
+export const ShowDetails = lodash.merge({},
     base,
     {
         args: {
-            customActions: {
+            showDetails: {
                 "io.kestra.plugin.jdbc.clickhouse.BulkInsert": {
                     label: "View SQL Config",
                     taskProp: "sql",
@@ -353,7 +353,7 @@ export const CustomAction = lodash.merge({},
             },
         },
         argTypes: {
-            onShowCustomAction: {action: "showCustomAction"},
+            onShowDetails: {action: "showDetails"},
         },
         loaders: [
             async () => ({
@@ -399,7 +399,7 @@ export const ExtraDetails = lodash.merge({},
                     height: node?.task ? 135 : getNodeHeight(node),
                 };
             },
-            customActions: {
+            showDetails: {
                 "io.kestra.plugin.jdbc.clickhouse.BulkInsert": {
                     label: "Show Details",
                     taskProp: "sql",
@@ -418,7 +418,7 @@ export const ExtraDetails = lodash.merge({},
             },
         },
         argTypes: {
-            onShowCustomAction: {action: "showCustomAction"},
+            onShowDetails: {action: "showDetails"},
         },
         loaders: [
             async () => ({
@@ -478,7 +478,6 @@ export const NodeDetails = lodash.merge({},
         ],
     }
 )
-
 
 
 

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -333,6 +333,7 @@ export const CustomNodes = lodash.merge({},
 )
 
 import NodeDetailsData from "../../data/graphs/node-details.js";
+import ExtraDetailsData from "../../data/graphs/extra-details.js";
 
 export const CustomAction = lodash.merge({},
     base,
@@ -357,6 +358,71 @@ export const CustomAction = lodash.merge({},
         loaders: [
             async () => ({
                 flowGraph: NodeDetailsData,
+                source: "",
+            }),
+        ],
+    }
+)
+
+export const ExtraDetails = lodash.merge({},
+    base,
+    {
+        args: {
+            isHorizontal: true,
+            taskDetails: (props) => {
+                const task = props?.data?.node.task || {};
+                const fields = ["project", "location", "namespace"].filter(k => task[k]);
+                if (!fields.length) return null;
+                return (
+                    <ul style={{
+                        textAlign: "left",
+                        padding: "0.5rem 0.75rem",
+                        margin: 0,
+                        listStyleType: "none",
+                        fontSize: "10px",
+                        borderTop: "1px solid var(--ks-border-primary)",
+                        backgroundColor: "var(--ks-background-body)",
+                        borderRadius: "0 0 .5rem .5rem",
+                    }}>
+                        {fields.map(key => (
+                            <li style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}
+                                title={`${key}: ${task[key]}`}>
+                                <strong>{key}:</strong> {task[key]}
+                            </li>
+                        ))}
+                    </ul>
+                );
+            },
+            getNodeDimensions(node, getNodeWidth, getNodeHeight) {
+                return {
+                    width: getNodeWidth(node),
+                    height: node?.task ? 135 : getNodeHeight(node),
+                };
+            },
+            customActions: {
+                "io.kestra.plugin.jdbc.clickhouse.BulkInsert": {
+                    label: "Show Details",
+                    taskProp: "sql",
+                    lang: "sql",
+                },
+                "io.kestra.plugin.serdes.avro.AvroToIon": {
+                    label: "Show Details",
+                    taskProp: "schema",
+                    lang: "yaml",
+                },
+                "io.kestra.plugin.azure.datafactory.CreateRun": {
+                    label: "Show Details",
+                    taskProp: "pipelineName",
+                    lang: "yaml",
+                },
+            },
+        },
+        argTypes: {
+            onShowCustomAction: {action: "showCustomAction"},
+        },
+        loaders: [
+            async () => ({
+                flowGraph: ExtraDetailsData,
                 source: "",
             }),
         ],

--- a/storybook/components/topology/Topology.stories.jsx
+++ b/storybook/components/topology/Topology.stories.jsx
@@ -341,12 +341,12 @@ export const ShowDetails = lodash.merge({},
         args: {
             showDetails: {
                 "io.kestra.plugin.jdbc.clickhouse.BulkInsert": {
-                    label: "View SQL Config",
+                    label: "Show Details",
                     taskProp: "sql",
                     lang: "sql",
                 },
                 "io.kestra.plugin.azure.datafactory.CreateRun": {
-                    label: "View Pipeline Config",
+                    label: "Show Details",
                     taskProp: "pipelineName",
                     lang: "yaml",
                 },
@@ -478,7 +478,6 @@ export const NodeDetails = lodash.merge({},
         ],
     }
 )
-
 
 
 

--- a/storybook/data/graphs/extra-details.js
+++ b/storybook/data/graphs/extra-details.js
@@ -1,0 +1,78 @@
+export default {
+    "nodes": [
+        {
+            "uid": "root.root-extraDetails",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterRoot"
+        },
+        {
+            "uid": "root.end-extraDetails",
+            "type": "io.kestra.core.models.hierarchies.GraphClusterEnd"
+        },
+        {
+            "uid": "root.IngestData",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "IngestData",
+                "type": "io.kestra.plugin.jdbc.clickhouse.BulkInsert",
+                "sql": "INSERT INTO events SELECT * FROM staging.events",
+                "project": "data-platform",
+                "location": "us-east-1",
+                "namespace": "company.analytics",
+            },
+            "relationType": "SEQUENTIAL"
+        },
+        {
+            "uid": "root.TransformAvro",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "TransformAvro",
+                "type": "io.kestra.plugin.serdes.avro.AvroToIon",
+                "schema": "s3://my-bucket/schemas/events.avsc",
+                "project": "data-platform",
+                "location": "eu-west-1",
+                "namespace": "company.etl",
+            },
+            "relationType": "SEQUENTIAL"
+        },
+        {
+            "uid": "root.RunPipeline",
+            "type": "io.kestra.core.models.hierarchies.GraphTask",
+            "task": {
+                "id": "RunPipeline",
+                "type": "io.kestra.plugin.azure.datafactory.CreateRun",
+                "pipelineName": "nightly-transform",
+                "project": "azure-pipelines",
+                "location": "westeurope",
+                "namespace": "company.azure",
+            },
+            "relationType": "SEQUENTIAL"
+        }
+    ],
+    "edges": [
+        {
+            "source": "root.root-extraDetails",
+            "target": "root.IngestData",
+            "relation": {}
+        },
+        {
+            "source": "root.IngestData",
+            "target": "root.TransformAvro",
+            "relation": {
+                "relationType": "SEQUENTIAL"
+            }
+        },
+        {
+            "source": "root.TransformAvro",
+            "target": "root.RunPipeline",
+            "relation": {
+                "relationType": "SEQUENTIAL"
+            }
+        },
+        {
+            "source": "root.RunPipeline",
+            "target": "root.end-extraDetails",
+            "relation": {}
+        },
+    ],
+    "clusters": []
+}


### PR DESCRIPTION
## Summary

- Adds a **ChevronDown/ChevronUp toggle button** on each task node in the topology view, placed next to the custom action button
- Clicking any node's toggle button **shows/hides extra metadata rows** (e.g. project, location) across **all nodes globally** — state is owned by `Topology.vue`
- Adds `TOGGLE_EXTRA_DETAILS` event to `EVENTS` constants
- Adds `showExtraDetails` prop to `TaskNode` (default: `true`)

## Test plan

- [ ] Open a flow with task nodes that render extra metadata rows (e.g. plugin-gcp with project/location)
- [ ] Verify a ChevronDown button appears on each task node next to the custom action button
- [ ] Click the toggle on any node — all nodes should collapse their extra detail rows simultaneously
- [ ] Click again — all rows reappear
- [ ] Verify the button tooltip reads "hide extra details" / "show extra details" correctly
- [ ] Verify export as image hides the toggle button (`.is-exporting` CSS rule)

Part-of: https://github.com/kestra-io/kestra/issues/12696#issuecomment-4267968234