### PR TITLE
feat(topology): label switch case branches on edges

### DIFF
--- a/src/components/nodes/EdgeNode.vue
+++ b/src/components/nodes/EdgeNode.vue
@@ -30,6 +30,19 @@
             </tooltip>
         </div>
     </EdgeLabelRenderer>
+
+    <EdgeLabelRenderer style="z-index: 9" v-if="path?.length && showCaseLabel">
+        <div
+            class="edge-case-label"
+            :style="{
+                position: 'absolute',
+                transform: `translate(-50%, -50%) translate(${caseLabelX}px,${caseLabelY}px)`,
+                pointerEvents: 'none',
+            }"
+        >
+            {{ data.value }}
+        </div>
+    </EdgeLabelRenderer>
 </template>
 
 <script lang="ts" setup>
@@ -120,6 +133,24 @@
 
     const labelXOffset = computed(() => 0);
 
+    const showCaseLabel = computed(() =>
+        props.data?.relationType === "CHOICE" && Boolean(props.data?.value)
+    );
+
+    const CASE_LABEL_GAP = 18;
+    const caseLabelX = computed(() => {
+        const tx = props.targetX ?? 0;
+        if (props.targetPosition === "left") return tx - CASE_LABEL_GAP;
+        if (props.targetPosition === "right") return tx + CASE_LABEL_GAP;
+        return tx;
+    });
+    const caseLabelY = computed(() => {
+        const ty = props.targetY ?? 0;
+        if (props.targetPosition === "top") return ty - CASE_LABEL_GAP;
+        if (props.targetPosition === "bottom") return ty + CASE_LABEL_GAP;
+        return ty;
+    });
+
     defineOptions({
         inheritAttrs: false,
     });
@@ -140,5 +171,20 @@
 
     .vue-flow__edge-path {
         stroke-dasharray: 3 5;
+    }
+
+    .edge-case-label {
+        font-size: 11px;
+        line-height: 1;
+        padding: 3px 6px;
+        border-radius: 4px;
+        background: var(--ks-background-card, #ffffff);
+        color: var(--ks-content-primary, #1b1c23);
+        border: 1px solid var(--ks-border-primary, #e1e3e5);
+        white-space: nowrap;
+        max-width: 160px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-family: var(--bs-font-monospace, ui-monospace, monospace);
     }
 </style>

--- a/src/utils/VueFlowUtils.test.ts
+++ b/src/utils/VueFlowUtils.test.ts
@@ -117,4 +117,114 @@ describe("VueFlowUtils", () => {
         currentGraph.nodes[1].task.outputFiles = ["file1-modified.txt", "file4.txt"];
         expect(VueFlowUtils.areTasksIdenticalInGraphUntilTask(previousGraph, currentGraph, "task4")).toBeFalsy();
     });
+
+    describe("generateGraph - case label data propagation", () => {
+        const issueFlowGraph = {
+            nodes: [
+                {
+                    uid: "root.render-language",
+                    type: "io.kestra.core.models.hierarchies.GraphTask",
+                    task: {id: "render-language", type: "io.kestra.plugin.core.flow.Switch"}
+                },
+                {
+                    uid: "root.render-language.french",
+                    type: "io.kestra.core.models.hierarchies.GraphTask",
+                    task: {id: "french", type: "io.kestra.plugin.core.debug.Return"}
+                },
+                {
+                    uid: "root.render-language.german",
+                    type: "io.kestra.core.models.hierarchies.GraphTask",
+                    task: {id: "german", type: "io.kestra.plugin.core.debug.Return"}
+                },
+                {
+                    uid: "root.render-language.english",
+                    type: "io.kestra.core.models.hierarchies.GraphTask",
+                    task: {id: "english", type: "io.kestra.plugin.core.debug.Return"}
+                }
+            ],
+            edges: [
+                {source: "root.render-language", target: "root.render-language.french", relation: {relationType: "CHOICE", value: "French"}},
+                {source: "root.render-language", target: "root.render-language.german", relation: {relationType: "CHOICE", value: "German"}},
+                {source: "root.render-language", target: "root.render-language.english", relation: {relationType: "CHOICE", value: "defaults"}}
+            ],
+            clusters: []
+        } as any;
+
+        const callGenerateGraph = (graph: any) =>
+            VueFlowUtils.generateGraph(
+                "vfid", "flow", "ns", graph, undefined,
+                [], false, {}, new Set(), [], true, false, false
+            ) ?? [];
+
+        test("propagates each case key from the issue flow to its CHOICE edge", () => {
+            const elements = callGenerateGraph(issueFlowGraph);
+            const edges = elements.filter((e: any) => e.type === "edge");
+
+            const frenchEdge = edges.find((e: any) => e.target === "root.render-language.french") as any;
+            expect(frenchEdge?.data?.value).toBe("French");
+            expect(frenchEdge?.data?.relationType).toBe("CHOICE");
+
+            const germanEdge = edges.find((e: any) => e.target === "root.render-language.german") as any;
+            expect(germanEdge?.data?.value).toBe("German");
+            expect(germanEdge?.data?.relationType).toBe("CHOICE");
+
+            const englishEdge = edges.find((e: any) => e.target === "root.render-language.english") as any;
+            expect(englishEdge?.data?.value).toBe("defaults");
+            expect(englishEdge?.data?.relationType).toBe("CHOICE");
+        });
+
+        test("does not set a case value on non-CHOICE edges", () => {
+            const sequentialFlowGraph = {
+                nodes: [
+                    {
+                        uid: "root.task1",
+                        type: "io.kestra.core.models.hierarchies.GraphTask",
+                        task: {id: "task1", type: "io.kestra.plugin.core.debug.Return"}
+                    },
+                    {
+                        uid: "root.task2",
+                        type: "io.kestra.core.models.hierarchies.GraphTask",
+                        task: {id: "task2", type: "io.kestra.plugin.core.debug.Return"}
+                    }
+                ],
+                edges: [
+                    {source: "root.task1", target: "root.task2", relation: {relationType: "SEQUENTIAL"}}
+                ],
+                clusters: []
+            } as any;
+
+            const edge = callGenerateGraph(sequentialFlowGraph)
+                .filter((e: any) => e.type === "edge")[0] as any;
+
+            expect(edge?.data?.value).toBeUndefined();
+            expect(edge?.data?.relationType).toBe("SEQUENTIAL");
+        });
+
+        test("leaves edge data fields undefined when relation is missing", () => {
+            const minimalFlowGraph = {
+                nodes: [
+                    {
+                        uid: "root.a",
+                        type: "io.kestra.core.models.hierarchies.GraphTask",
+                        task: {id: "a", type: "io.kestra.plugin.core.debug.Return"}
+                    },
+                    {
+                        uid: "root.b",
+                        type: "io.kestra.core.models.hierarchies.GraphTask",
+                        task: {id: "b", type: "io.kestra.plugin.core.debug.Return"}
+                    }
+                ],
+                edges: [
+                    {source: "root.a", target: "root.b"}
+                ],
+                clusters: []
+            } as any;
+
+            const edge = callGenerateGraph(minimalFlowGraph)
+                .filter((e: any) => e.type === "edge")[0] as any;
+
+            expect(edge?.data?.value).toBeUndefined();
+            expect(edge?.data?.relationType).toBeUndefined();
+        });
+    });
 });

--- a/src/utils/VueFlowUtils.ts
+++ b/src/utils/VueFlowUtils.ts
@@ -695,6 +695,8 @@ export function generateGraph(
                         edge.source.startsWith(TRIGGERS_NODE_UID),
                     color: edgeColor,
                     unused: (edge as any).unused,
+                    value: (edge as any).relation?.value,
+                    relationType: (edge as any).relation?.relationType,
                 },
                 style: {
                     zIndex: 10,


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/2072.

## Summary

Adds the case key (`French`, `defaults`, `then`, `else`, ...) above each branch target in the topology graph for tasks that fan out via `RelationType.CHOICE` (Switch and If/Else). Other edge types (`SEQUENTIAL`, `ERROR`, `FINALLY`, `AFTER_EXECUTION`) are unchanged.

## What changed in the code

**`src/utils/VueFlowUtils.ts`** (+2 lines, in `generateGraph`)
Propagates `edge.relation.value` and `edge.relation.relationType` from the backend `FlowGraph` payload into the Vue Flow edge `data` object. The Java `Relation` model already carries these fields for Switch cases and If/Else branches (verified against `FlowGraphTest.java` and live against Kestra OSS 1.3.14), so no backend change is required.

**`src/components/nodes/EdgeNode.vue`** (+44 lines)
Adds a second `<EdgeLabelRenderer>` block that renders `data.value` as a small pill on the edge. It only shows when `data.relationType === "CHOICE"` and `data.value` is set, so non-CHOICE edges look exactly like before. Position is anchored to `targetX`/`targetY` plus a fixed `CASE_LABEL_GAP` perpendicular to the target's `targetPosition` (`top` / `bottom` / `left` / `right`), which keeps the offset consistent across edge lengths and across vertical/horizontal topology orientations. Styling uses theme variables with light fallbacks so labels stay readable when the theme isn't loaded (e.g. in Storybook).

## Vue Flow APIs used

Everything is built on documented Vue Flow primitives — no SVG-by-hand, no overrides of internal layout logic.

- [`<EdgeLabelRenderer>`](https://vueflow.dev/typedocs/functions/EdgeLabelRenderer.html) — Vue Flow's `<Teleport>` that renders DOM into the `vue-flow__edge-labels` layer above the SVG. Already used in `EdgeNode.vue` for the `AddTaskButton`; the case label uses a second instance in the same component.
- [Custom edge props `targetX` / `targetY` / `targetPosition`](https://vueflow.dev/guide/edge.html#custom-edges) — Vue Flow passes these to every custom edge component. `targetPosition` is the [`Position` enum](https://vueflow.dev/typedocs/enumerations/Position.html) (`"top"` / `"bottom"` / `"left"` / `"right"`) telling us which handle the edge enters. Anchoring the label at `(targetX, targetY)` plus a `GAP` along that axis keeps the offset consistent regardless of edge length or topology orientation.
- [`getSmoothStepPath(props)`](https://vueflow.dev/typedocs/functions/getSmoothStepPath.html) — already in use to build the path string and to position the `AddTaskButton` at the path midpoint (`path[1]` / `path[2]`); not used for the case label because the smooth-step midpoint sits at the elbow of the path on long fan-outs, which visually disconnects the label from its target node.

## Tests

3 unit tests added in `src/utils/VueFlowUtils.test.ts`. **The CHOICE test fixture mirrors the exact backend payload for the YAML attached to issue #2072** (Switch `render-language` with `French` / `German` cases plus a `defaults` branch on `english`):

- `propagates each case key from the issue flow to its CHOICE edge`
- `does not set a case value on non-CHOICE edges`
- `leaves edge data fields undefined when relation is missing`

Suite: 163/163 passing. `vue-tsc --project ./tsconfig.build.json` clean.

## Screenshots

Verified live against Kestra OSS 1.3.14 with the published `kestra/kestra:latest` backend, the patched `ui-libs` linked into Kestra UI dev server (Vite) at `http://localhost:5173`.

### 1. Issue's exact flow (`French` / `German` / `defaults`)

Same flow as the issue:

![Issue flow — Switch with French / German / defaults](https://raw.githubusercontent.com/flcarre/ui-libs/pr-assets/switch-edge-labels/pr-1-issue-flow.png)

### 2. Switch with 4 cases

Stress-tests the placement when targets are spread over more horizontal space:

![Switch with 4 cases — French / German / Spanish / defaults](https://raw.githubusercontent.com/flcarre/ui-libs/pr-assets/switch-edge-labels/pr-2-four-cases.png)

### 3. If/Else nesting a Switch

Same `RelationType.CHOICE` mechanism handles both branch types, so `then` / `else` on the outer If/Else and the case keys on the inner Switch render with the same logic. Useful as a regression check that the placement does not drift when paths are very different lengths (the `else` edge is much longer than the `then` edge).

![If/Else with nested Switch](https://raw.githubusercontent.com/flcarre/ui-libs/pr-assets/switch-edge-labels/pr-3-if-else.png)