### PR TITLE
docs: add sunset notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  > [!WARNING]
-> **This repository is sunsetting.** All components have been moved into the design system of the [Kestra OSS repository](https://github.com/kestra-io/kestra). No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
+> **This repository is sunsetting.** All components have been moved into the [design system](https://github.com/kestra-io/kestra/tree/develop/ui/packages) of the [Kestra OSS repository](https://github.com/kestra-io/kestra). No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
 
 <p align="center">
   <a href="https://www.kestra.io">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+ > [!WARNING]
+> **This repository is sunsetting.** All components have been moved into the design system of the [Kestra OSS repository](https://github.com/kestra-io/kestra). No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
+
 <p align="center">
   <a href="https://www.kestra.io">
     <img width="460" src="https://kestra.io/logo.svg"  alt="Kestra workflow orchestrator" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  > [!WARNING]
-> **This repository is sunsetting.** All components have been moved into the [design system](https://github.com/kestra-io/kestra/tree/develop/ui/packages) of the [Kestra OSS repository](https://github.com/kestra-io/kestra). No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
+> **This repository is sunsetting.** All components have been moved into the [design system](https://github.com/kestra-io/kestra/tree/develop/ui/packages) of the Kestra OSS repository. No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
 
 <p align="center">
   <a href="https://www.kestra.io">


### PR DESCRIPTION
## Summary

- Adds a prominent warning banner at the top of the README noting that `ui-libs` is sunsetting
- All components have been moved into the OSS repository's design system
- The repository will not be archived in case a new version is needed for a previous Kestra LTS release