### PR TITLE
docs: add spacing between sunset notice and rest of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
  > [!WARNING]
 > **This repository is sunsetting.** All components have been moved into the [design system](https://github.com/kestra-io/kestra/tree/develop/ui/packages) of the Kestra OSS repository. No new versions will be released under normal circumstances. The repository will **not** be archived, as new versions may still be published if required to support previous Kestra LTS releases.
 
+&nbsp;
+
+&nbsp;
+
 <p align="center">
   <a href="https://www.kestra.io">
     <img width="460" src="https://kestra.io/logo.svg"  alt="Kestra workflow orchestrator" />


### PR DESCRIPTION
Adds a few lines of spacing between the warning alert and the rest of the README content for better readability.