### PR TITLE
fix(topology): center the info icon in the controls panel

### DIFF
--- a/src/components/topology/Topology.vue
+++ b/src/components/topology/Topology.vue
@@ -547,7 +547,8 @@
 
 <style lang="scss" src="./topology.scss" />
 <style scoped lang="scss">
-    .material-design-icon.download-icon {
+    .material-design-icon.download-icon,
+    .material-design-icon.information-icon {
         max-width: 12px;
     }
 


### PR DESCRIPTION
## Summary

- Apply `max-width: 12px` to `.material-design-icon.information-icon` in the `Topology.vue` scoped styles, grouping it with the existing `.download-icon` rule
- This constrains the `vue-material-design-icons` span to the correct 12 px width so the ℹ️ icon renders centered within the VueFlow `ControlButton`, consistent with the other controls

## Test plan

- [ ] Open the topology view and verify the ℹ️ (info / show extra details) button is visually centred alongside the other control buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)