### PR TITLE
feat(plugins): remove hardcoded H2 heading from plugin description section

### DIFF
--- a/src/components/plugins/PluginIndex.vue
+++ b/src/components/plugins/PluginIndex.vue
@@ -53,10 +53,7 @@
             </div>
         </template>
         <template v-if="description !== undefined && plugin?.longDescription">
-            <div class="description">
-                <h2 id="how-to-use-this-plugin">
-                    How to use this plugin
-                </h2>
+            <div id="how-to-use-this-plugin" class="description">
                 <div ref="contentWrap" class="markdown-container" :class="{expanded: isExpanded}">
                     <div ref="contentInner" class="markdown-inner">
                         <slot name="markdown" :content="description.replace(/ *:(?![ /])/g, ': ')" />


### PR DESCRIPTION
## Summary

- Removes the hardcoded `<h2>How to use this plugin</h2>` from `PluginIndex.vue`
- Moves the `id="how-to-use-this-plugin"` anchor to the wrapper `<div class="description">` so the right-sidebar TOC link still resolves correctly
- Plugin authors can now supply their own H1 heading directly in the plugin's doc markdown file (e.g. `src/main/resources/doc/io.kestra.plugin.aws.md`)

## Test plan

- [ ] Visit a plugin page that has a `longDescription` (e.g. `/plugins/plugin-aws`) — the section should no longer show a hardcoded "How to use this plugin" H2
- [ ] The H1 from the plugin's markdown file renders as the section heading
- [ ] The right-sidebar TOC entry still links to `#how-to-use-this-plugin` and scrolls correctly
- [ ] Plugins without a doc markdown file are unaffected

Part-of: https://github.com/kestra-io/docs/issues/4688